### PR TITLE
feat: initialize pnpm monorepo and shared configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,37 @@ The stack is live. All tickets follow the full workflow.
 - E2E tests: `*.e2e-spec.ts` (in `e2e/` directory)
 
 **Validation pipeline (run in order):**
-1. `npm run lint` (ESLint)
-2. `npm run format:check` (Prettier)
-3. `npm run test` (Vitest)
-4. `npm run test:e2e` (Playwright)
+1. `pnpm run lint` (ESLint)
+2. `pnpm run format:check` (Prettier)
+3. `pnpm run test` (Vitest)
+4. `pnpm run test:e2e` (Playwright)
+
+---
+
+## Monorepo Structure (pnpm Workspaces)
+
+**Layout:**
+```
+/                        ← repo root (@hc/root)
+  apps/
+    backend/             ← NestJS app (@hc/backend)
+    frontend/            ← Angular app (@hc/frontend)
+  pnpm-workspace.yaml
+  package.json
+  tsconfig.base.json
+```
+
+**Package manager:** pnpm (>=9). Always use `pnpm` — never `npm` or `yarn`.
+
+**Common commands:**
+- `pnpm install` — install all workspace dependencies
+- `pnpm --filter @hc/backend <cmd>` — run a command in the backend package
+- `pnpm --filter @hc/frontend <cmd>` — run a command in the frontend package
+- `pnpm -r <cmd>` — run a command recursively across all workspace packages
+
+**Adding dependencies:**
+- Root dev tooling: `pnpm add -D <pkg> -w` (workspace root flag)
+- Per-app: `pnpm --filter @hc/backend add <pkg>`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@hc/root",
+  "version": "0.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=20",
+    "pnpm": ">=9"
+  },
+  "scripts": {
+    "install:all": "pnpm install"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'apps/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": false,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- Initialize pnpm workspace with `apps/*` layout for the @hc monorepo
- Add shared `tsconfig.base.json` (strict, ES2022, bundler resolution)
- Update `CLAUDE.md` with pnpm commands and monorepo structure documentation

## Changes
- `pnpm-workspace.yaml` — workspace root
- `package.json` — @hc/root, private, engines constraint
- `.npmrc` — shamefully-hoist + no strict peers
- `tsconfig.base.json` — shared TypeScript base config
- `pnpm-lock.yaml` — lockfile
- `CLAUDE.md` — monorepo structure section added

## Verification
- [x] `pnpm install` completes successfully
- [x] `pnpm-workspace.yaml` references `apps/*`
- [x] `tsconfig.base.json` has strict, ES2022, bundler resolution
- [x] `.npmrc` has required pnpm settings
- [x] `CLAUDE.md` updated with pnpm workflow

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)