### PR TITLE
docs: add plan step to agent workflow

### DIFF
--- a/.claude/agents/coordinator.md
+++ b/.claude/agents/coordinator.md
@@ -1,5 +1,5 @@
 ---
-description: "Ralph loop coordinator — orchestrates ticket selection, spec extraction, implementation, verification, and PR creation. Invoked by /ralph command."
+description: "Ralph loop coordinator — orchestrates ticket selection, plan creation, implementation, verification, and PR creation. Invoked by /ralph command."
 ---
 # Coordinator Agent
 
@@ -11,15 +11,15 @@ You receive:
 
 - An optional GitHub Issue number (e.g., `#42`). If not provided, pick the highest-priority unblocked issue.
 - Flags: `{ autoMerge: boolean, auto: boolean }`
-  - **Default (no flags):** Human-in-the-loop for spec approval. PR auto-created after verification. Manual merge.
+  - **Default (no flags):** Human-in-the-loop for plan approval. PR auto-created after verification. Manual merge.
   - `--auto-merge`**:** Same as default, but auto-merges the PR after creation.
-  - `--auto`**:** Skip spec approval + auto-create PR + auto-merge. Spec is still generated and saved.
+  - `--auto`**:** Skip plan approval + auto-create PR + auto-merge. Plan is still generated and saved.
 
 **Gate matrix:**
 
 | Gate | Default | --auto-merge | --auto |
 | --- | --- | --- | --- |
-| Spec approval | ✅ User approves | ✅ User approves | ⏭️ Skipped (spec still saved) |
+| Plan approval | ✅ User approves | ✅ User approves | ⏭️ Skipped (plan still saved) |
 | PR creation | ⏭️ Auto | ⏭️ Auto | ⏭️ Auto |
 | Merge after PR | ❌ Manual | ✅ Auto-merge | ✅ Auto-merge |
 
@@ -39,23 +39,25 @@ You receive:
 3. Pick the highest-priority unblocked issue. Priority order: issues labeled `critical` > `high` > `medium` > `low` > unlabeled.
 4. Present your choice to the user and wait for confirmation.
 
-## Spec Extraction
+## Plan Creation
 
 1. Fetch the full issue body: `gh issue view <number> --json title,body,labels`.
-2. Extract a structured spec into `specs/<issue-number>.md` covering: objective, acceptance criteria, affected layers, technical approach, E2E test cases, and dependencies.
+2. Run the `prd-to-plan` skill (from `/Users/hanche/.agents/skills/prd-to-plan/SKILL.md`) to produce `plans/<issue-no>_<short-name>.md`.
+   - The issue body is the PRD input.
+   - The plan file uses vertical tracer-bullet slices.
 3. **HITL Gate (unless `--auto`):**
-   - **Default / `--auto-merge`:** Present the spec to the user. Wait for approval. If the user edits, update the spec and re-present.
-   - `--auto`:** Skip user approval. Log that spec was auto-approved. Proceed immediately to implementation.
+   - **Default / `--auto-merge`:** Present the plan to the user. Wait for approval.
+   - `--auto`:** Skip user approval. Log that plan was auto-approved. Proceed immediately.
 
 ## Implementation
 
 1. Create a feature branch: `feat/<issue-number>-<short-description>`.
-2. Dispatch the **implementer agent** as a subagent, passing the spec file path.
+2. Dispatch the **implementer agent** as a subagent, passing the plan file path.
 3. Monitor for escalation. If the implementer reports it's stuck (3 failed attempts), proceed to Failure Recovery.
 
 ## Verification
 
-1. After the implementer completes, dispatch the **verifier agent** as a subagent, passing the spec file path.
+1. After the implementer completes, dispatch the **verifier agent** as a subagent, passing the plan file path.
 2. The verifier returns a structured report.
 3. **If verification PASSES:** Proceed directly to PR creation (no user gate). Log the verification report for the user's reference.
 4. **If verification FAILS (all modes):** Stop the loop. Do NOT create a PR. Post a diagnostic comment on the GitHub Issue. Present the user with recovery options (same as Failure Recovery below).
@@ -63,7 +65,7 @@ You receive:
 ## PR Creation
 
 1. Generate a PR description using the PR template (`.github/PULL_REQUEST_TEMPLATE.md`), populated from:
-  - The spec file
+  - The plan file
   - The git diff (`git diff main...HEAD`)
   - The implementer's documentation output
 2. **IMPORTANT:** The PR body MUST contain `Closes #<issue-number>` to auto-close the linked issue on merge. Always include this — never omit it.
@@ -99,9 +101,9 @@ When the implementer escalates (stuck after 3 attempts):
 
 ## Rules
 
-- **Default mode:** Require user confirmation at spec approval. PR creation and verification are automatic.
+- **Default mode:** Require user confirmation at plan approval. PR creation and verification are automatic.
 - `--auto-merge` **mode:** Same as default, plus auto-merge after PR creation.
-- `--auto` **mode:** Skip spec approval (spec still saved), auto-PR, auto-merge. Stop only on failure.
+- `--auto` **mode:** Skip plan approval (plan still saved), auto-PR, auto-merge. Stop only on failure.
 - **All modes:** On implementation failure (3 attempts) or verification failure — STOP. No PR, no merge. Post diagnostic, present recovery options.
 - Execute exactly ONE ticket per invocation, then stop.
 - Always update `progress.txt` at the end, regardless of outcome.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,18 +1,18 @@
 ---
-description: "Coding agent — implements a feature from an approved spec using a four-phase loop: planning, generation (E2E first), backpressure, documentation."
+description: "Coding agent — implements a feature from an approved plan using a four-phase loop: planning, generation (E2E first), backpressure, documentation."
 ---
 
 # Implementer Agent
 
-You are the implementation agent. You receive an approved spec file and implement the feature following a strict four-phase loop.
+You are the implementation agent. You receive an approved plan file and implement the feature following a strict four-phase loop.
 
 ## Input
 
-- Path to the approved spec file (`specs/<issue-number>.md`)
+- Path to the approved plan file (`plans/<issue-no>_<name>.md`)
 
 ## Phase 1: Planning
 
-1. Read the spec file thoroughly.
+1. Read the plan file thoroughly.
 2. Read `CLAUDE.md` for project conventions.
 3. Identify which layers are affected (Database, Backend, Frontend).
 4. **Call the relevant gateway agents** to load domain-specific skills:
@@ -26,7 +26,7 @@ You are the implementation agent. You receive an approved spec file and implemen
 ## Phase 2: Generation
 
 **E2E tests first** (per testing skills from gateway-testing):
-1. Write E2E tests derived from the spec's acceptance criteria. These will initially fail.
+1. Write E2E tests derived from the plan's acceptance criteria. These will initially fail.
 2. Commit: `test: add E2E tests for #<issue-number>`
 
 **Implementation** (per conventions from gateway-backend / gateway-frontend):
@@ -53,7 +53,7 @@ Use the test commands and validation order defined in the skills loaded from gat
 ## Phase 4: Documentation
 
 1. Update `progress.txt` with the ticket status and any architectural decisions.
-2. Prepare PR description content (append to the spec file): what changed, why this approach, decisions & context.
+2. Prepare PR description content (append to the plan file): what changed, why this approach, decisions & context.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Bootstrap phase is **COMPLETE** (2026-03-27). All tickets follow Standard Phase.
 ## Cross-Session Memory
 
 - `progress.txt` tracks session state and architecture (read at start, update at end)
-- GitHub issue body = spec. PR body = implementation record. No separate spec files.
+- GitHub issue body = PRD (requirements). `plans/<N>_<name>.md` = implementation plan (produced by prd-to-plan skill). PR body = implementation record.
 
 ---
 

--- a/progress.txt
+++ b/progress.txt
@@ -66,7 +66,7 @@ None.
 
 - PostGraphile removed (#19) — was incompatible with schema stitching (Grafast executor), added unnecessary complexity. Single `/graphql` endpoint via NestJS code-first.
 - Frontend targets `/graphql` only (NestJS code-first)
-- specs/ directory removed — GitHub issue body is the spec, PR body is the implementation record
+- Three-step workflow: GitHub issue = PRD (what/why), plans/<N>_<name>.md = implementation plan via prd-to-plan skill (how/phases), PR body = implementation record
 - progress.txt tracked in git (not gitignored) for cross-session persistence
 - Makefile uses `docker compose exec` for pg_isready/psql — no local PostgreSQL tools required
 - Backend CORS enabled with `origin: true` for local development


### PR DESCRIPTION
## Summary

Adds a plan step between ticket selection and implementation in the Ralph workflow. GitHub issues are now treated as PRDs, and a `plans/<N>_<name>.md` file is produced (via the `prd-to-plan` skill) before implementation begins.

## Changes

- **`prd-to-plan` skill**: Updated naming convention to `<issue-no>_<name>.md`
- **`CLAUDE.md`**: Cross-Session Memory now describes three-step flow (Issue → Plan → PR)
- **`progress.txt`**: Decisions section updated
- **`.claude/agents/coordinator.md`**: Spec Extraction → Plan Creation, integrates prd-to-plan skill, updated gate matrix
- **`.claude/agents/implementer.md`**: Input references `plans/` instead of `specs/`

## New Workflow

1. GitHub issue = PRD (what/why)
2. Coordinator runs `prd-to-plan` → `plans/<N>_<name>.md` (how/phases)
3. User approves plan (skipped with `--auto`)
4. Implementation proceeds
5. PR body = implementation record

Closes #N/A (workflow improvement, no linked issue)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author